### PR TITLE
Fixed PHP Parse error

### DIFF
--- a/usr/share/openmediavault/engined/rpc/omvextrasorg.inc
+++ b/usr/share/openmediavault/engined/rpc/omvextrasorg.inc
@@ -180,7 +180,7 @@ class OMVRpcServiceOmvExtrasOrg extends OMVRpcServiceAbstract
             $arch = 2;
         } elseif ( strpos($uname, "486") !== false ||
                    strpos($uname, "586") !== false ||
-                   strpos($uname, "686") !== false || ) {
+                   strpos($uname, "686") !== false ) {
             $arch = 3;
         } elseif ( strpos($uname, "amd64") !== false ||
                    strpos($uname, "x86_64") !== false ) {


### PR DESCRIPTION
Running: omv-engined -d -f 

results in:
PHP Parse error:  syntax error, unexpected ')' in /usr/share/openmediavault/engined/rpc/omvextrasorg.inc on line 183