### PR TITLE
Fix for Jessie

### DIFF
--- a/usr/share/openmediavault/mkconf/omvextrasorg
+++ b/usr/share/openmediavault/mkconf/omvextrasorg
@@ -188,7 +188,8 @@ EOF
         apt-key adv --keyserver ${KEYSERVER} --recv-keys "FDA5DFFC"
         echo "# mono-project repo" >> ${OMVEXTRASREPOFILE}
         echo "deb ${BINTRAY_REPO}/${OMVVERSION}-mono ${RELEASE} main" >> ${OMVEXTRASREPOFILE}
-        echo "deb http://download.mono-project.com/repo/debian ${RELEASE} main" >> ${OMVEXTRASREPOFILE}
+        echo "deb http://download.mono-project.com/repo/debian wheezy main" >> ${OMVEXTRASREPOFILE}
+        echo "deb http://download.mono-project.com/repo/debian wheezy-libjpeg62-compat main" >> ${OMVEXTRASREPOFILE}
         cat <<EOF >> ${OMVEXTRASAPTPREFS}
 Package: *
 Pin: release n=${OMVVERSION}-mono, origin ${BINTRAY_REPO_LOCATION}


### PR DESCRIPTION
mono-project.com does not host ${RELEASE} named repositories. 

http://www.mono-project.com/docs/getting-started/install/linux/#libgdiplus-debian-80-and-later-not-ubuntu

Additional test case may need to be added to exclude "libjpeg62-compat" repository on older debian versions.