### PR TITLE
fix rebooting to SystemRescueCD

### DIFF
--- a/usr/share/openmediavault/mkconf/omvextras
+++ b/usr/share/openmediavault/mkconf/omvextras
@@ -414,7 +414,7 @@ case $1 in
     ;;
 
     rebootsys)
-        installsysresccd
+        rebootsysresccd
     ;;
 
     configure)


### PR DESCRIPTION
calling `/usr/share/openmediavault/mkconf/omvextras rebootsys` triggered SystemRescueCD _installation_ instead of setting as a one-time default boot entry.