### PR TITLE
No analytics by Portainer per default

### DIFF
--- a/usr/sbin/omv-installdocker
+++ b/usr/sbin/omv-installdocker
@@ -300,7 +300,7 @@ installPortainer()
 
   # pull and start portainer
   echo "Pulling and starting portainer ..."
-  docker run -d --name "${portainerName}" -p 9000:9000 -p 8000:8000 --restart=unless-stopped -v /var/run/docker.sock:/var/run/docker.sock -v ${portainerVolume}:/data portainer/portainer
+  docker run -d --name "${portainerName}" -p 9000:9000 -p 8000:8000 --restart=unless-stopped -v /var/run/docker.sock:/var/run/docker.sock -v ${portainerVolume}:/data portainer/portainer --no-analytics
   if [ $? -gt 0 ]; then
     echo "Something went wrong trying to pull and start portainer ..."
   fi


### PR DESCRIPTION
Portainer collects data on the user using Google Analytics.

Even with the `--no-analytics` flag, Google get's requests by this decision on the side of portainer. See https://github.com/portainer/portainer/issues/3310 for details. Another possibility would be to give the user granular opt-in/out options, which is hopefully pursued by portainer soon.

This pull requests addresses issue #32.