### PR TITLE
Fix cockpit dependency in buster-backports

### DIFF
--- a/srv/salt/omv/deploy/omvextras/files/etc-apt-preferences_d-omvextras_pref.j2
+++ b/srv/salt/omv/deploy/omvextras/files/etc-apt-preferences_d-omvextras_pref.j2
@@ -34,6 +34,10 @@ Package: qemu*
 Pin: release a={{ grains['oscodename'] }}-backports
 Pin-Priority: 500
 
+Package: libfdt1
+Pin: release a={{ grains['oscodename'] }}-backports
+Pin-Priority: 500
+
 Package: borgbackup
 Pin: release a={{ grains['oscodename'] }}-backports
 Pin-Priority: 500

--- a/usr/sbin/omv-installdocker
+++ b/usr/sbin/omv-installdocker
@@ -57,7 +57,7 @@ setCockpitPackages()
 {
   cockpitPackages="cockpit cockpit-packagekit"
   if [[ "${arch}" == "amd64" ]] || [[ "${arch}" == "i386" ]]; then
-    cockpitPackages="${cockpitPackages} cockpit-machines virtinst qemu-utils libvirt-dbus cockpit-storaged dnsmasq-base"
+    cockpitPackages="${cockpitPackages} cockpit-machines virtinst qemu-system-x86 qemu-utils libvirt-dbus cockpit-storaged dnsmasq-base"
   fi
 }
 


### PR DESCRIPTION
### Fix QEMU dependency in buster-backports
QEMU update dependency in buster-backports
libfdt need to be updated to buster-backports too
Pin libfdt* to buster-backports
affected: libfdt1, libfdt-dev

### Fix install cockpit dependency
cockpit only depend on libvirt, but libvirt didn't depend on qemu-system-x86 or qemu-kvm