### PR TITLE
Add TLS support for portainer's admin UI

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+openmediavault-omvextrasorg (6.0.8) stable; urgency=low
+
+  * Add TLS support for portainer's admin UI
+
+ -- OpenMediaVault Plugin Developers <plugins@omv-extras.org>  Sun, 20 Feb 2022 20:04:36 +0100
+
 openmediavault-omvextrasorg (6.0.7) stable; urgency=low
 
   * Add container status widget

--- a/usr/sbin/omv-installdocker
+++ b/usr/sbin/omv-installdocker
@@ -105,6 +105,8 @@ setConfig()
     echo "Agent port:: ${agentport}"
     webport=$(omv_config_get "${xpath}/webport")
     echo "Web port:: ${webport}"
+    enabletls=$(omv_config_get "${xpath}/enabletls")
+    echo "Enable TLS:: ${enabletls}"
     yachtport=$(omv_config_get "${xpath}/yachtport")
     echo "Yacht port:: ${yachtport}"
     ee=$(omv_config_get "${xpath}/ee")
@@ -415,9 +417,44 @@ installPortainer()
     docker volume create "${portainerVolume}"
   fi
 
+  # Extra configuration
+  declare -a opts=()
+  declare -a args=()
+  local omvtlsenabled certuuid
+
+  omvtlsenabled="$(omv_config_get "/config/webadmin/enablessl")"
+
+  if (( enabletls )) && (( omvtlsenabled )); then
+    certuuid="$(omv_config_get "/config/webadmin/sslcertificateref")"
+
+    # https://docs.portainer.io/v/ce-2.11/advanced/ssl#docker-standalone
+    args+=(
+      --sslcert /certs/openmediavault.crt
+      --sslkey /certs/openmediavault.key
+    )
+    opts+=(
+      -p "$webport":9443
+      -v /etc/ssl/certs/openmediavault-"$certuuid".crt:/certs/openmediavault.crt:ro
+      -v /etc/ssl/private/openmediavault-"$certuuid".key:/certs/openmediavault.key:ro
+    )
+  else
+    if (( enabletls )); then
+      echo "Cannot enable TLS for portainer as it is not enabled for OMV."
+    fi
+    opts+=(-p "$webport":9000)
+  fi
+
   # pull and start portainer
   echo "Pulling and starting ${portainerImage} ..."
-  docker run -d --name "${portainerName}" -p ${webport}:9000 -p ${agentport}:8000 --restart=unless-stopped -v /var/run/docker.sock:/var/run/docker.sock -v ${portainerVolume}:/data ${portainerImage}
+
+  docker run -d --name "$portainerName" \
+    --restart=unless-stopped \
+    -p "$agentport":8000 \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v "$portainerVolume":/data \
+    "${opts[@]}" \
+    "$portainerImage" "${args[@]}"
+
   if [ $? -gt 0 ]; then
     echo "Something went wrong trying to pull and start portainer ..."
   fi

--- a/usr/share/openmediavault/confdb/create.d/conf.system.omvextras.sh
+++ b/usr/share/openmediavault/confdb/create.d/conf.system.omvextras.sh
@@ -35,6 +35,9 @@ fi
 if ! omv_config_exists "/config/system/omvextras/webport"; then
     omv_config_add_key "/config/system/omvextras" "webport" "9000"
 fi
+if ! omv_config_exists "/config/system/omvextras/enabletls"; then
+    omv_config_add_key "/config/system/omvextras" "enabletls" "1"
+fi
 if ! omv_config_exists "/config/system/omvextras/agentport"; then
     omv_config_add_key "/config/system/omvextras" "agentport" "8000"
 fi

--- a/usr/share/openmediavault/confdb/migrations.d/conf.system.omvextras_6.0.8.sh
+++ b/usr/share/openmediavault/confdb/migrations.d/conf.system.omvextras_6.0.8.sh
@@ -1,0 +1,30 @@
+#!/bin/sh
+#
+# @license   http://www.gnu.org/licenses/gpl.html GPL Version 3
+# @author    Volker Theile <volker.theile@openmediavault.org>
+# @author    OpenMediaVault Plugin Developers <plugins@omv-extras.org>
+# @copyright Copyright (c) 2009-2013 Volker Theile
+# @copyright Copyright (c) 2013-2022 OpenMediaVault Plugin Developers
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program. If not, see <http://www.gnu.org/licenses/>.
+
+set -e
+
+. /usr/share/openmediavault/scripts/helper-functions
+
+if ! omv_config_exists "/config/system/omvextras/enabletls"; then
+    omv_config_add_key "/config/system/omvextras" "enabletls" "0"
+fi
+
+exit 0

--- a/usr/share/openmediavault/datamodels/conf.system.omvextras.json
+++ b/usr/share/openmediavault/datamodels/conf.system.omvextras.json
@@ -27,6 +27,10 @@
 			"maximum": 65535,
 			"default": 8000
 		},
+		"enabletls": {
+			"type": "boolean",
+			"default": true
+		},
 		"yachtport": {
 			"type": "integer",
 			"minimum": 1000,

--- a/usr/share/openmediavault/datamodels/rpc.omvextras.json
+++ b/usr/share/openmediavault/datamodels/rpc.omvextras.json
@@ -44,6 +44,10 @@
 				"maximum": 65535,
 				"required": true
 			},
+			"enabletls": {
+				"type": "boolean",
+				"required": false
+			},
 			"ee": {
 				"type": "boolean",
 				"required": false

--- a/usr/share/openmediavault/engined/rpc/omvextras.inc
+++ b/usr/share/openmediavault/engined/rpc/omvextras.inc
@@ -189,6 +189,7 @@ class OMVRpcServiceOmvExtras extends \OMV\Rpc\ServiceAbstract
         }
         $object->set('agentport',$params['agentport']);
         $object->set('webport',$params['webport']);
+        $object->set('enabletls',$params['enabletls']);
         $object->set('ee',$params['ee']);
         $db->set($object);
         // Return the configuration object.

--- a/usr/share/openmediavault/locale/en_US/openmediavault-omvextrasorg.po
+++ b/usr/share/openmediavault/locale/en_US/openmediavault-omvextrasorg.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the openmediavault-omvextrasorg package.
-# 
+#
 # Translators:
 msgid ""
 msgstr ""
@@ -411,6 +411,9 @@ msgstr "Use EE"
 
 msgid "Use business edition. This version requires a license."
 msgstr "Use business edition. This version requires a license."
+
+msgid "Use OMV's TLS configuration for Portainer's admin interface."
+msgstr "Use OMV's TLS configuration for Portainer's admin interface."
 
 msgid "Use legacy"
 msgstr "Use legacy"

--- a/usr/share/openmediavault/locale/fr_FR/openmediavault-omvextrasorg.po
+++ b/usr/share/openmediavault/locale/fr_FR/openmediavault-omvextrasorg.po
@@ -1,7 +1,7 @@
 # SOME DESCRIPTIVE TITLE.
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the openmediavault-omvextrasorg package.
-# 
+#
 # Translators:
 # Axel Cantenys, 2017-2018,2021
 # Etienne V, 2020
@@ -415,6 +415,9 @@ msgstr ""
 
 msgid "Use business edition. This version requires a license."
 msgstr ""
+
+msgid "Use OMV's TLS configuration for Portainer's admin interface."
+msgstr "Utiliser la configuration TLS de OMV pour l'interface d'adminitration de Portainer."
 
 msgid "Use legacy"
 msgstr "Utiliser la version legacy"

--- a/usr/share/openmediavault/locale/openmediavault-omvextrasorg.pot
+++ b/usr/share/openmediavault/locale/openmediavault-omvextrasorg.pot
@@ -77,6 +77,9 @@ msgstr ""
 msgid "Downloads SystemRescue ISO and configures grub bootloader to allow booting from ISO."
 msgstr ""
 
+msgid "Enable TLS"
+msgstr ""
+
 msgid "Extras repo"
 msgstr ""
 
@@ -372,6 +375,9 @@ msgid "Use EE"
 msgstr ""
 
 msgid "Use business edition. This version requires a license."
+msgstr ""
+
+msgid "Use OMV's TLS configuration for Portainer's admin interface."
 msgstr ""
 
 msgid "Use legacy"

--- a/usr/share/openmediavault/workbench/component.d/omv-system-omvextras-portainer-form-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-system-omvextras-portainer-form-page.yaml
@@ -25,7 +25,12 @@ data:
           min: 1
           max: 65535
           patternType: port
-          required: true 
+          required: true
+      - type: checkbox
+        name: enabletls
+        label: _("Enable TLS")
+        hint: _("Use OMV's TLS configuration")
+        value: true
       - type: numberInput
         name: agentport
         label: _("Agent port")
@@ -34,7 +39,7 @@ data:
           min: 1
           max: 65535
           patternType: port
-          required: true 
+          required: true
       - type: checkbox
         name: ee
         label: _("Use EE")


### PR DESCRIPTION
Allows using OMV Admin UI's TLS configuration for the Portainer Admin UI as well.
Similar to what was requested in #36 but with a simpler UI (the certificate cannot be selected).

As this is my first time developing for OMV (and I'm not familiar with Angular), I expect this needs some cleanup.
In particular:
- I don't know how the translations should be updated, just did two manually
- I already bumped the version in the changelog and prepared a migration script with that version number, because I don't know how to test except for building and installing the package
- Whatever other things I'm not aware of for integrating such a thing with the rest of OMV, in particular you will probably need to manually re-install Portainer if the certificate changes in OMV.

I hope this gets the ball rolling :)