### PR TITLE
Certificate picker for portainer based on OMV's

### DIFF
--- a/usr/sbin/omv-installdocker
+++ b/usr/sbin/omv-installdocker
@@ -105,8 +105,6 @@ setConfig()
     echo "Agent port:: ${agentport}"
     webport=$(omv_config_get "${xpath}/webport")
     echo "Web port:: ${webport}"
-    enabletls=$(omv_config_get "${xpath}/enabletls")
-    echo "Enable TLS:: ${enabletls}"
     yachtport=$(omv_config_get "${xpath}/yachtport")
     echo "Yacht port:: ${yachtport}"
     ee=$(omv_config_get "${xpath}/ee")
@@ -115,6 +113,21 @@ setConfig()
       portainerImage="${portainerImage/ce/ee}"
     fi
     echo "image:: ${portainerImage}"
+
+    enabletls=$(omv_config_get "${xpath}/enabletls")
+    echo "Enable TLS:: ${enabletls}"
+    if (( enabletls )); then
+      local tlscert_uuid tlscert_name missing_crt missing_key
+      tlscert_uuid=$(omv_config_get "${xpath}/tlscertificateref")
+      tlscert_name="$(omv_config_get "//system/certificates/sslcertificate[uuid = '${tlscert_uuid}']/comment")"
+      tlscert_crt="${OMV_SSL_CERTIFICATE_DIR}/certs/${OMV_SSL_CERTIFICATE_PREFIX:-openmediavault-}${tlscert_uuid}.crt"
+      tlscert_key="${OMV_SSL_CERTIFICATE_DIR}/private/${OMV_SSL_CERTIFICATE_PREFIX:-openmediavault-}${tlscert_uuid}.key"
+      if [ ! -f "$tlscert_crt" ]; then missing_crt=1; fi
+      if [ ! -f "$tlscert_key" ]; then missing_key=1; fi
+      echo "TLS certificate:: ${tlscert_name}"
+      echo "  crt: ${missing_crt:+(NOT FOUND) }${tlscert_crt}"
+      echo "  key: ${missing_key:+(NOT FOUND) }${tlscert_key}"
+    fi
   fi
 }
 
@@ -418,15 +431,9 @@ installPortainer()
   fi
 
   # Extra configuration
-  declare -a opts=()
-  declare -a args=()
-  local omvtlsenabled certuuid
+  local opts args
 
-  omvtlsenabled="$(omv_config_get "/config/webadmin/enablessl")"
-
-  if (( enabletls )) && (( omvtlsenabled )); then
-    certuuid="$(omv_config_get "/config/webadmin/sslcertificateref")"
-
+  if (( enabletls )) && [ -f "$tlscert_crt" ] && [ -f "$tlscert_key" ]; then
     # https://docs.portainer.io/v/ce-2.11/advanced/ssl#docker-standalone
     args+=(
       --sslcert /certs/openmediavault.crt
@@ -434,13 +441,13 @@ installPortainer()
     )
     opts+=(
       -p "$webport":9443
-      -v /etc/ssl/certs/openmediavault-"$certuuid".crt:/certs/openmediavault.crt:ro
-      -v /etc/ssl/private/openmediavault-"$certuuid".key:/certs/openmediavault.key:ro
+      -v "$tlscert_crt":/certs/openmediavault.crt:ro
+      -v "$tlscert_key":/certs/openmediavault.key:ro
     )
+  elif (( enabletls )); then
+    echo "The selected certificate cannot be used."
+    opts+=(-p "$webport":9443)
   else
-    if (( enabletls )); then
-      echo "Cannot enable TLS for portainer as it is not enabled for OMV."
-    fi
     opts+=(-p "$webport":9000)
   fi
 

--- a/usr/share/openmediavault/confdb/create.d/conf.system.omvextras.sh
+++ b/usr/share/openmediavault/confdb/create.d/conf.system.omvextras.sh
@@ -35,9 +35,6 @@ fi
 if ! omv_config_exists "/config/system/omvextras/webport"; then
     omv_config_add_key "/config/system/omvextras" "webport" "9000"
 fi
-if ! omv_config_exists "/config/system/omvextras/enabletls"; then
-    omv_config_add_key "/config/system/omvextras" "enabletls" "0"
-fi
 if ! omv_config_exists "/config/system/omvextras/agentport"; then
     omv_config_add_key "/config/system/omvextras" "agentport" "8000"
 fi
@@ -46,6 +43,12 @@ if ! omv_config_exists "/config/system/omvextras/yachtport"; then
 fi
 if ! omv_config_exists "/config/system/omvextras/ee"; then
     omv_config_add_key "/config/system/omvextras" "ee" "0"
+fi
+if ! omv_config_exists "/config/system/omvextras/enabletls"; then
+    omv_config_add_key "/config/system/omvextras" "enabletls" "0"
+fi
+if ! omv_config_exists "/config/system/omvextras/tlscertificateref"; then
+    omv_config_add_key "/config/system/omvextras" "tlscertificateref" ""
 fi
 
 # remove backports from sources.list

--- a/usr/share/openmediavault/datamodels/conf.system.omvextras.json
+++ b/usr/share/openmediavault/datamodels/conf.system.omvextras.json
@@ -27,10 +27,6 @@
 			"maximum": 65535,
 			"default": 8000
 		},
-		"enabletls": {
-			"type": "boolean",
-			"default": true
-		},
 		"yachtport": {
 			"type": "integer",
 			"minimum": 1000,
@@ -40,6 +36,20 @@
 		"ee": {
 			"type": "boolean",
 			"default": false
+		},
+		"enabletls": {
+			"type": "boolean",
+			"default": false
+		},
+		"tlscertificateref": {
+			"type": "string",
+			"oneOf": [{
+				"type": "string",
+				"format": "uuidv4"
+			},{
+				"type": "string",
+				"maxLength": 0
+			}]
 		}
 	}
 }

--- a/usr/share/openmediavault/datamodels/rpc.omvextras.json
+++ b/usr/share/openmediavault/datamodels/rpc.omvextras.json
@@ -44,13 +44,17 @@
 				"maximum": 65535,
 				"required": true
 			},
+			"ee": {
+				"type": "boolean",
+				"required": false
+			},
 			"enabletls": {
 				"type": "boolean",
 				"required": false
 			},
-			"ee": {
-				"type": "boolean",
-				"required": false
+			"tlscertificateref": {
+				"type": "string",
+				"required": true
 			}
 		}
 	}

--- a/usr/share/openmediavault/engined/rpc/omvextras.inc
+++ b/usr/share/openmediavault/engined/rpc/omvextras.inc
@@ -189,8 +189,9 @@ class OMVRpcServiceOmvExtras extends \OMV\Rpc\ServiceAbstract
         }
         $object->set('agentport',$params['agentport']);
         $object->set('webport',$params['webport']);
-        $object->set('enabletls',$params['enabletls']);
         $object->set('ee',$params['ee']);
+        $object->set('enabletls',$params['enabletls']);
+        $object->set('tlscertificateref',$params['tlscertificateref']);
         $db->set($object);
         // Return the configuration object.
         return $object->getAssoc();

--- a/usr/share/openmediavault/locale/openmediavault-omvextrasorg.pot
+++ b/usr/share/openmediavault/locale/openmediavault-omvextrasorg.pot
@@ -77,9 +77,6 @@ msgstr ""
 msgid "Downloads SystemRescue ISO and configures grub bootloader to allow booting from ISO."
 msgstr ""
 
-msgid "Enable TLS"
-msgstr ""
-
 msgid "Extras repo"
 msgstr ""
 
@@ -372,12 +369,6 @@ msgid "Updates"
 msgstr ""
 
 msgid "Use EE"
-msgstr ""
-
-msgid "Use OMV's TLS configuration"
-msgstr ""
-
-msgid "Use OMV's TLS configuration for Portainer's admin interface."
 msgstr ""
 
 msgid "Use business edition. This version requires a license."

--- a/usr/share/openmediavault/workbench/component.d/omv-system-omvextras-portainer-form-page.yaml
+++ b/usr/share/openmediavault/workbench/component.d/omv-system-omvextras-portainer-form-page.yaml
@@ -26,11 +26,6 @@ data:
           max: 65535
           patternType: port
           required: true
-      - type: checkbox
-        name: enabletls
-        label: _("Enable TLS")
-        hint: _("Use OMV's TLS configuration")
-        value: true
       - type: numberInput
         name: agentport
         label: _("Agent port")
@@ -45,6 +40,20 @@ data:
         label: _("Use EE")
         hint: _("Use business edition. This version requires a license.")
         value: false
+      - type: checkbox
+        name: enabletls
+        label: _("SSL/TLS enabled")
+        value: false
+      - type: sslCertSelect
+        name: tlscertificateref
+        label: _("Certificate")
+        hasEmptyOption: true
+        value: ''
+        modifiers:
+          - type: enabled
+            constraint: { operator: 'truthy', arg0: { prop: 'enabletls' } }
+        validators:
+          requiredIf: { operator: 'truthy', arg0: { prop: 'enabletls' } }
     buttons:
       - template: submit
       - template: cancel


### PR DESCRIPTION
Follow-up to #66

This MR adds a certificate picker, the same as in OMV's web admin settings (System > Workbench > Secure connection).
I also reused the translations from OMV, so I removed the strings I added in #66 from the pot file. This way we can benefit from all the existing OMV translations for free.