### PR TITLE
Use Docker’s GPG key for Debian

### DIFF
--- a/srv/salt/omv/deploy/omvextras/default.sls
+++ b/srv/salt/omv/deploy/omvextras/default.sls
@@ -23,7 +23,7 @@
 {% set dist = pillar['productinfo']['distribution'] %}
 {% set repo_url = salt['pillar.get']('default:OMV_EXTRAS_APT_REPOSITORY_URL', 'https://openmediavault-plugin-developers.github.io/packages/debian') -%}
 {% set docker_url = salt['pillar.get']('default:OMV_DOCKER_APT_REPOSITORY_URL', 'https://download.docker.com/linux/debian') -%}
-{% set docker_key = salt['pillar.get']('default:OMV_DOCKER_KEY_URL', 'https://download.docker.com/linux/ubuntu/gpg') -%}
+{% set docker_key = salt['pillar.get']('default:OMV_DOCKER_KEY_URL', 'https://download.docker.com/linux/debian/gpg') -%}
 {% set list = '/etc/apt/sources.list.d/omvextras.list' %}
 {% set pref = '/etc/apt/preferences.d/omvextras.pref' %}
 


### PR DESCRIPTION
Use URL from Docker’s official installation instructions for Debian, even though the actual GPG key is the same for both URLs.

By the way, how is this key actually used? For example `/etc/apt/sources.list.d/pvekernel.list` explicitly defines the key with signed-by:

```
deb [arch=amd64 signed-by=/usr/share/keyrings/proxmox-release-bullseye.gpg] http://download.proxmox.com/debian/pve bullseye pve-no-subscription
```

But `/etc/apt/sources.list.d/omvextras.list` doesn't:
```
deb [arch=amd64] https://download.docker.com/linux/debian bullseye stable
```

The [Docker installation instructions for Debian](https://docs.docker.com/engine/install/debian/#install-using-the-repository) explicitly define the key with signed-by.

Could we add the Docker repo in the same way as the Proxmox repo?