### PR TITLE
Update omv-aptclean to better track backports zfs package updates

### DIFF
--- a/usr/sbin/omv-aptclean
+++ b/usr/sbin/omv-aptclean
@@ -86,7 +86,7 @@ if [ "${1}" = "repos" ]; then
   if omv_checkyesno ${backports}; then
     ((i++))
     echo -e "\n${i}. Adding backports pinning..."
-    pkgs=("zfs*" "libnvpair3linux" "libzfs4linux" "libzpool5linux" "libuutil3linux" "libfdt1" "borgbackup" "libvirt*" "qemu*" "seabios")
+    pkgs=("zfs*" "libnvpair*linux" "libzfs*linux" "libzpool*linux" "libuutil*linux" "libfdt1" "borgbackup" "libvirt*" "qemu*" "seabios")
     for ((j=0; j<${#pkgs[@]}; j++)); do
       echo -e "Package: ${pkgs[j]}\nPin: release n=${dist}-backports\nPin-Priority: ${OMV_APT_KERNEL_BACKPORTS_PINPRIORITY}\n" >> ${pref}
     done

--- a/usr/sbin/omv-aptclean
+++ b/usr/sbin/omv-aptclean
@@ -86,7 +86,7 @@ if [ "${1}" = "repos" ]; then
   if omv_checkyesno ${backports}; then
     ((i++))
     echo -e "\n${i}. Adding backports pinning..."
-    pkgs=("zfs*" "libnvpair*linux" "libzfs*linux" "libzpool*linux" "libuutil*linux" "libfdt1" "borgbackup" "libvirt*" "qemu*" "seabios")
+    pkgs=("*zfs*" "*zpool*" "libnvpair*linux" "libuutil*linux" "libfdt1" "borgbackup" "libvirt*" "qemu*" "seabios")
     for ((j=0; j<${#pkgs[@]}; j++)); do
       echo -e "Package: ${pkgs[j]}\nPin: release n=${dist}-backports\nPin-Priority: ${OMV_APT_KERNEL_BACKPORTS_PINPRIORITY}\n" >> ${pref}
     done

--- a/usr/sbin/omv-aptclean
+++ b/usr/sbin/omv-aptclean
@@ -86,7 +86,7 @@ if [ "${1}" = "repos" ]; then
   if omv_checkyesno ${backports}; then
     ((i++))
     echo -e "\n${i}. Adding backports pinning..."
-    pkgs=("*zfs*" "*zpool*" "libnvpair*linux" "libuutil*linux" "libfdt1" "borgbackup" "libvirt*" "qemu*" "seabios")
+    pkgs=("src:zfs-linux" "libfdt1" "borgbackup" "libvirt*" "qemu*" "seabios")
     for ((j=0; j<${#pkgs[@]}; j++)); do
       echo -e "Package: ${pkgs[j]}\nPin: release n=${dist}-backports\nPin-Priority: ${OMV_APT_KERNEL_BACKPORTS_PINPRIORITY}\n" >> ${pref}
     done


### PR DESCRIPTION
This commit changes the omvextras.pref file to better and more accurately track zfs package changes upstream in the backports release.

Specifically, current (as-of-today) version number changes in bookworm-backports for libzpool5linux -> libzpool6linux and libzfs4linux -> libzfs6linux.

Use of wildcards should future-proof this commit.

Also introduces wildcards for the libnvpair3linux and libuutil3linux packages, to also future-proof potential upstream changes in those zfs related packages.

Consider using `"*zfs*"` and `"*zpool*"` as wildcard entries in future commit, so that 3 entries can be reduced to 2 to cover packages currently covered by `"zfs*"` `"libzfs*linux"` and `"libzpool*linux"`